### PR TITLE
Prefix table with source when db is not the default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,14 @@ export async function hasuraCamelize(
   const data = await api.fetchData(dbOptions);
 
   for (const tableName in data) {
+    let tableNameWithSource = tableName;
+
+    if (dbOptions.source !== 'default') {
+      tableNameWithSource = `${dbOptions.source}_${tableName}`;
+    }
+
     const tableNames = transformTableNames(
-      tableName,
+      tableNameWithSource,
       defaults.tableNameTransformer
     );
     if (!tableNames) continue;


### PR DESCRIPTION
Prefixing the table with the source name when the db is not the default
avoids naming conflicts.  i.e. if both databases have a table named
`orders`