### PR TITLE
Fix issue with multiple schemas issue and add insecure TLS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ hasura-camelize --host https://some.domain --secret some-secret --relations --pg
 - _optional_ _new_ relations: relation names to be renamed
 - _optional_ _new_ pgMaterializedViews: Rename postgresql materialized views/columns also
 - _optional_ _new_ pattern: Renaming pattern, default will result in names e.g. 'usersInsert', 'invert' results in e.g. 'insertUsers'
+- _optional_ _new_ insecure-skip-tls-verify: Allow for insecure https hasura endpoints (eg, self signed certificates). Not recommended for use against production deployments.
 
 ## From code
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const { Agent } = require('https');
 const { resolve } = require('path');
 require('dotenv').config({ path: resolve(process.cwd(), '.env') });
 const yargs = require('yargs/yargs');
@@ -11,6 +12,10 @@ const {
   defaultSource,
 } = require('../build/main');
 
+const agent = new Agent({
+    rejectUnauthorized: !argv.insecureSkipTlsVerify ?? true
+});
+
 const exclude = argv.exclude && argv.exclude.split(',').map((x) => x.trim());
 const include = argv.include && argv.include.split(',').map((x) => x.trim());
 
@@ -20,6 +25,7 @@ hasuraCamelize(
     secret: argv.secret || argv['admin-secret'] || process.env.HASURA_GRAPHQL_ADMIN_SECRET,
     schema: argv.schema || process.env.HASURA_GRAPHQL_SCHEMA || defaultSchema,
     source: argv.source || process.env.HASURA_GRAPHQL_SOURCE || defaultSource,
+    agent: agent,
   },
   {
     dry: argv.dry,

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,11 +24,13 @@ export async function fetchData({
   secret,
   schema = defaultSchema,
   source = defaultSource,
+  agent
 }: DBOptionsType) {
   const { result } = await fetchJson<{ result: string[][] }>(
     `${host}/v2/query`,
     {
       method: 'post',
+      agent: agent,
       body: {
         type: 'run_sql',
         args: {
@@ -52,9 +54,11 @@ export async function fetchPGMaterializedViewData({
   secret,
   schema = defaultSchema,
   source = defaultSource,
+  agent
 }: DBOptionsType) {
   const views = await fetchJson<{ result: string[][] }>(`${host}/v2/query`, {
     method: 'post',
+    agent: agent,
     body: {
       type: 'run_sql',
       args: {
@@ -79,6 +83,7 @@ export async function fetchPGMaterializedViewData({
     `${host}/v2/query`,
     {
       method: 'post',
+      agent: agent,
       body: {
         type: 'run_sql',
         args: {
@@ -111,7 +116,7 @@ export async function fetchPGMaterializedViewData({
 }
 
 export async function pushData(
-  { host, secret, schema, source = defaultSource }: DBOptionsType,
+  { host, secret, schema, source = defaultSource, agent }: DBOptionsType,
   args: {
     tableName: string;
     customTableName: string;
@@ -121,6 +126,7 @@ export async function pushData(
 ) {
   await fetchJson(`${host}/v1/metadata`, {
     method: 'post',
+    agent: agent,
     body: {
       type: 'pg_set_table_customization',
       args: {
@@ -141,7 +147,7 @@ export async function pushData(
 }
 
 export async function pushRelationshipData(
-  { host, secret, schema, source = defaultSource }: DBOptionsType,
+  { host, secret, schema, source = defaultSource, agent }: DBOptionsType,
   args: {
     tableName: string;
     oldName: string;
@@ -150,6 +156,7 @@ export async function pushRelationshipData(
 ) {
   await fetchJson(`${host}/v1/metadata`, {
     method: 'post',
+    agent: agent,
     body: {
       type: 'pg_rename_relationship',
       args: {
@@ -169,9 +176,11 @@ export async function pushRelationshipData(
 export async function getMetadata({
   host,
   secret,
+  agent
 }: DBOptionsType): Promise<MetadataType> {
   const data = await fetch(`${host}/v1/metadata`, {
     method: 'post',
+    agent: agent,
     body: JSON.stringify({
       type: 'export_metadata',
       version: 2,

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ export async function hasuraCamelize(
             if (rel.name !== newName && newName) {
               console.log(`${rel.name} => ${newName}`);
               if (!dry) {
-                await api.pushRelationshipData(dbOptions, {
+                await api.pushRelationshipData(Object.assign({}, dbOptions, {schema: table.table.schema}), {
                   tableName: table.table.name,
                   newName,
                   oldName: rel.name,
@@ -134,7 +134,7 @@ export async function hasuraCamelize(
             if (rel.name !== newName && newName) {
               console.log(`${rel.name} => ${newName}`);
               if (!dry) {
-                await api.pushRelationshipData(dbOptions, {
+                await api.pushRelationshipData(Object.assign({}, dbOptions, {schema: table.table.schema}), {
                   tableName: table.table.name,
                   newName,
                   oldName: rel.name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,11 @@
+import type { Agent } from 'https'
+
 export interface DBOptionsType {
   host: string;
   secret: string;
   source?: string;
   schema?: string;
+  agent?: Agent;
 }
 
 export type RootFieldsType = {


### PR DESCRIPTION
When there are multiple schemas, the `pushRelationshipData` function would end up reading the relationships from one schema but still try to apply it to the default schema and end up with an error since the relationship didn't exist on the default schema. This fixes that by specifying the schema from the metadata.

Also, added an option for insecure TLS for self signed certificates. This shouldn't be used against production hasura endpoints (users should have valid TLS certificates for that), but if a user is dealing with self-signed certificates (such as for local development using HTTPS still) this feature allows those connections now.