### PR TITLE
Fix bug where http endpoints would use HTTPS agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ convert(
 
 ## Changes
 
+### 2.0.2
+
+- Fix: Parse http(s) prototcol from args and use the appropriate HTTP agent type
+
+### 2.0.1
+
+- Add: --insecure-skip-tls-verify argument
+
 ### 2.0.0
 
 - Add: updateMany and selectStream root fields

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hasura-camelize",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
   "module": "build/module/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,12 @@
-import type { Agent } from 'https';
+import type { Agent as AgentHttp } from 'http';
+import type { Agent as AgentHttps } from 'https';
 
 export interface DBOptionsType {
   host: string;
   secret: string;
   source?: string;
   schema?: string;
-  agent?: Agent;
+  agent?: AgentHttp | AgentHttps;
 }
 
 export type RootFieldsType = {


### PR DESCRIPTION
This PR fixes an issue where the current version v2.0.1 errors for HTTP endpoints.

Example error:

```
$ npx hasura-camelize --host http://localhost:8080 --secret <redacted>

--- Settings ---
host: http://localhost:8080
secret: <secret>
schema: public
source: default
agent: [object Object]
dry: false
relations: false

--- Starting ---
TypeError [ERR_INVALID_PROTOCOL]: Protocol "http:" not supported. Expected "https:"
    at new NodeError (node:internal/errors:399:5)
    at new ClientRequest (node:_http_client:189:11)
    at request (node:http:98:10)
    at /<redacted>/hasura-camelize/node_modules/node-fetch/lib/index.js:1482:15
    at new Promise (<anonymous>)
    at fetch (/<redacted>/hasura-camelize/node_modules/node-fetch/lib/index.js:1451:9)
    at Object.getMetadata (/<redacted>/hasura-camelize/build/main/api.js:144:49)
    at hasuraCamelize (/<redacted>/hasura-camelize/build/main/index.js:50:28)
    at Object.<anonymous> (/<redacted>/hasura-camelize/bin/cli.js:22:1)
    at Module._compile (node:internal/modules/cjs/loader:1254:14) {
  code: 'ERR_INVALID_PROTOCOL'
```